### PR TITLE
OOC Verification

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -118,6 +118,17 @@
 			<a href='?src=[ref];mute=[M.ckey];mute_type=[MUTE_DEADCHAT]'><font color='[(muted & MUTE_DEADCHAT) ? "#ff5e5e" : "white"]'>DEADCHAT</font></a>
 			(<a href='?src=[ref];mute=[M.ckey];mute_type=[MUTE_ALL]'><font color='[(muted & MUTE_ALL) ? "#ff5e5e" : "white"]'>ALL</font></a>)
 		"}
+	
+	if(M.client)
+		var/verified = M.client.prefs.age_verified
+		if(verified)
+			body += {"<br><b>Age Verification: </b>
+					<a href='?src=[ref];verify=[M.ckey]'><font color='[(verified) ? "#ff5e5e" : "#5e84ff"]'>Unverify</font></a>
+					"}
+		else
+			body += {"<br><b>Age Verification: </b>
+					<a href='?src=[ref];verify=[M.ckey]'><font color='[(verified) ? "#ff5e5e" : "#5e84ff"]'>Verify</font></a>
+					"}
 
 	body += {"
 		<br><br>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1533,6 +1533,13 @@
 			log_admin("INVALID ADMIN PROC ACCESS: [key_name(usr)] tried to use /datum/admins/proc/CheckAdminHref(): mute without admin perms.")
 			return
 		cmd_admin_mute(href_list["mute"], text2num(href_list["mute_type"]))
+	
+	else if(href_list["verify"])
+		if(!check_rights(R_ADMIN))
+			message_admins("[ADMIN_TPMONTY(usr)] tried to use /datum/admins/proc/CheckAdminHref(): verify without admin perms.")
+			log_admin("INVALID ADMIN PROC ACCESS: [key_name(usr)] tried to use /datum/admins/proc/CheckAdminHref(): verify without admin perms.")
+			return
+		cmd_admin_verify(href_list["verify"])
 
 	else if(href_list["c_mode"])
 		return HandleCMode()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -218,6 +218,40 @@
 	admin_ticket_log(M, msg)
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Godmode", "[M.status_flags & GODMODE ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/proc/cmd_admin_verify(whom)
+	if(!whom)
+		return
+
+	var/verifyunverify
+	
+	var/client/C
+	if(istype(whom, /client))
+		C = whom
+	else if(istext(whom))
+		C = GLOB.directory[whom]
+	else
+		return
+
+	var/datum/preferences/P
+	if(C)
+		P = C.prefs
+	else
+		P = GLOB.preferences_datums[whom]
+	if(!P)
+		return
+	
+	if(P.age_verified)
+		verifyunverify = "unverified"
+		P.age_verified = 0
+	else
+		verifyunverify = "verified"
+		P.age_verified = 1
+
+	log_admin("[key_name(usr)] has [verifyunverify] [key_name(whom)]")
+	message_admins("[key_name_admin(usr)] has [verifyunverify] [key_name_admin(whom)].")
+	if(C)
+		to_chat(C, "You have been [verifyunverify] by [key_name(usr, include_name = FALSE)].", confidential = TRUE)
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Age Verification", "[P.age_verified ? "Verified" : "Unverified"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /proc/cmd_admin_mute(whom, mute_type, automute = 0)
 	if(!whom)

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -161,7 +161,7 @@ then the player gets the profit from selling his own wasted time.
 	var/total_value = ex.total_value[src]
 	var/total_amount = ex.total_amount[src]
 
-	var/msg = "[total_value] credits: Received [total_amount] "
+	var/msg = "[total_value] caps: Received [total_amount] "
 	if(total_value > 0)
 		msg = "+" + msg
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -14,6 +14,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//non-preference stuff
 	var/muted = 0
+	var/age_verified = 0
 	var/last_ip
 	var/last_id
 	var/log_clicks = FALSE

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -460,8 +460,6 @@
 
 	if(client.prefs.age_verified)
 		. += span_boldnotice("This player is Age Verified.")
-	if(!client.prefs.age_verified)
-		. += span_boldwarning("This player is not Age Verified.")
 
 	if(has_status_effect(STATUS_EFFECT_ADMINSLEEP))
 		. += span_danger("<B>This player has been slept by staff.</B>\n")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -458,6 +458,11 @@
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .) //This also handles flavor texts now
 
+	if(client.prefs.age_verified)
+		. += span_boldnotice("This player is Age Verified.")
+	if(!client.prefs.age_verified)
+		. += span_boldwarning("This player is not Age Verified.")
+
 	if(has_status_effect(STATUS_EFFECT_ADMINSLEEP))
 		. += span_danger("<B>This player has been slept by staff.</B>\n")
 


### PR DESCRIPTION
Adds a way to display age verification in game

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- NOTE: This format is NOT REQUIRED for things like runtime fixes, code fixes and optimizations. In those instances you should try to give a description of what is being fixed or optimized but are not required to fill out the complete changelog. -->
<!-- Adjusting things like armor or weapon values for balance, while they may be 'fixes' in their own way, are not considered code fixes as described above and require the use of the Pull Request format below.-->


## About The Pull Request
Once a player has been age verified via discord, they staff can get on the server and verify them via the player panel. Once the player has been verified, below their OOC Notes link, a message saying that they're verified will appear. 

![Screenshot (1007)](https://github.com/thegrovellingpeasant/Project-Buchanan/assets/51186688/33f360f0-4ee2-4695-8a5f-8b36ef371c23)

Note: The player panel won't update the action of (un)verifying the user unless the window is closed and re-opened
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more security for players
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Added a way for staff to age verify people in game, which will display on their characters
tweak: Changed credits to caps in the message you receive when you export something
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
