### PR TITLE
adds text trimming & fixes init order

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -272,11 +272,33 @@
 
 	return ""
 
+#if DM_VERSION < 515
+//Returns a string with reserved characters and spaces after the first and last letters removed
+//Like trim(), but very slightly faster. worth it for niche usecases
+//This was replaced in BYOND version 515 with a built-in proc, rendering this useless.
+/proc/trimtext(text)
+	var/starting_coord = 1
+	var/text_len = length(text)
+	for (var/i in 1 to text_len)
+		if (text2ascii(text, i) > 32)
+			starting_coord = i
+			break
+
+	for (var/i = text_len, i >= starting_coord, i--)
+		if (text2ascii(text, i) > 32)
+			return copytext(text, starting_coord, i + 1)
+
+	if(starting_coord > 1)
+		return copytext(text, starting_coord)
+	return ""
+
+#endif
+
 //Returns a string with reserved characters and spaces before the first word and after the last word removed.
 /proc/trim(text, max_length)
 	if(max_length)
 		text = copytext_char(text, 1, max_length)
-	return trim_left(trim_right(text))
+	return trimtext(text)
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(t as text)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -46,15 +46,17 @@ GLOBAL_VAR(restart_counter)
 
 	SetupExternalRSC()
 
-	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
-
 	GLOB.config_error_log = GLOB.world_manifest_log = GLOB.world_pda_log = GLOB.world_job_debug_log = GLOB.sql_error_log = GLOB.world_href_log = GLOB.world_runtime_log = GLOB.world_attack_log = GLOB.world_game_log = GLOB.world_shuttle_log = "data/logs/config_error.[GUID()].log" //temporary file used to record errors with loading config, moved to log directory once logging is set bl
 
 	GLOB.revdata = new
 
-	InitTgs()
-
+	//This has to load before datum references and after revdata, otherwise you'll runtime.
 	config.Load(params[OVERRIDE_CONFIG_DIRECTORY_PARAMETER])
+
+	make_datum_references_lists()	//initialises global lists for referencing frequently used datums (so that we only ever do it once)
+
+	//This, similarly, has to load after revdata.
+	InitTgs()
 
 	load_admins()
 	load_mentors()

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -90,6 +90,9 @@
 /proc/_num2text(N, SigFig = 6)
 	return num2text(N, SigFig)
 
+/proc/_trimtext(Text)
+	return trimtext(Text)
+
 /proc/_ohearers(Dist, Center = usr)
 	return ohearers(Dist, Center)
 


### PR DESCRIPTION
## About The Pull Request

adds a new 515 built-in byond proc, trimtext, for ``trim``, for versions of byond running 515+
Also fixes the init order to stop the 2 runtimes at the start of each compile

less runtimes and a small micro optimization for fun.
