### PR TITLE
removes runtime every bootup

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -556,7 +556,8 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/setup_officer_positions()
 	var/datum/job/J = SSjob.GetJob("Vault-tec Security")
 	if(!J)
-		CRASH("setup_officer_positions(): Security officer job is missing")
+		log_job_debug("setup_officer_positions(): There is no assigned/dedicated Security Officer job, no positions will be scaled.")
+		return
 
 	var/ssc = CONFIG_GET(number/security_scaling_coeff)
 	if(ssc > 0)


### PR DESCRIPTION
## About The Pull Request

The default map Reno doesn't have a security officer job, so this runtimes at the start of every single round.
Replaces it with a job debug log, so it's still there just not as a runtime since it's not unintended.